### PR TITLE
to build rindow-openblas for windows on vs2017

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.14)
 #set(CMAKE_CONFIGURATION_TYPES Debug Release)
 enable_testing()
 
-project(rindow-matlib VERSION 1.0.0 LANGUAGES CXX C)
+project(rindow-matlib VERSION 1.0.1 LANGUAGES CXX C)
 #set(PROJECT_VERSION_MAJOR 1)
 #set(PROJECT_VERSION_MINOR 0)
-#set(PROJECT_VERSION_PATCH 0)
+#set(PROJECT_VERSION_PATCH 1)
 
 # GoogleTest requires at least C++14
 set(CMAKE_CXX_STANDARD 14)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Unzip the package file from packages directory.
 C> PATH %PATH%;C:\path\to\bin
 ```
 
-How to build from source code on Ubuntu
+How to build from source code on Linux
 =======================================
 You can also build and use from source code.
 
@@ -121,7 +121,7 @@ Download source code from release and extract
 
 - https://github.com/rindow/rindow-matlib/releases
 
-### Build and Install on Ubuntu
+### Build and Install on Linux
 
 Build with cmake.
 
@@ -213,6 +213,6 @@ int main(int ac, char **av)
 
 C> cl /EHsc -I.\path\to\include sample.cpp \path\to\lib\rindowmatlib.lib
 
-### build the sample program on Ubuntu.
+### build the sample program on Linux.
 
 $ g++ sample.cpp -lrindowmatlib -lm

--- a/src/common.c
+++ b/src/common.c
@@ -560,9 +560,7 @@ int32_t rindow_matlib_common_rand()
     int32_t number;
     number = (((((int32_t)rand())<<17)|(((int32_t)rand())<<2)) ^ (int32_t)rand());
     return (int32_t)(number & 0x7fffffff);
-    ERROR !!
 #else
-    ERROR !!
     // VS2019
     unsigned int number;
     if(rand_s( &number )) {

--- a/src/common.c
+++ b/src/common.c
@@ -554,20 +554,36 @@ int32_t rindow_matlib_common_d_argmax(int32_t n, double *x, int32_t incX)
 
 int32_t rindow_matlib_common_rand()
 {
-#if _MSC_VER
+#ifdef _MSC_VER
+#if (_MSC_VER % 100 ) <= 16
+    // VS2017
+    int32_t number;
+    number = (((((int32_t)rand())<<17)|(((int32_t)rand())<<2)) ^ (int32_t)rand());
+    return (int32_t)(number & 0x7fffffff);
+    ERROR !!
+#else
+    ERROR !!
+    // VS2019
     unsigned int number;
     if(rand_s( &number )) {
         return 0;
     }
-    return (int32_t)number & 0x7fffffff;
+    return (int32_t)(number & 0x7fffffff);
+#endif
 #else
+    // Linux
     return random();
 #endif
 }
 void rindow_matlib_common_srand(int32_t seed)
 {
-#if _MSC_VER
+#ifdef _MSC_VER
+#if (_MSC_VER % 100 ) <= 16
+    // VS2017
+    srand((unsigned int)seed);
+#endif
 #else
+    // Linux
     srandom(seed);
 #endif
 }


### PR DESCRIPTION
php7.x requires building with VS2017.
When building with rindow-openblas and referring to rindow-matlib, it says that the rand_s function is missing.
When building with VS2017, I used rand three times instead.
However, there are no plans to build rindow-matlib alone with VS2017.
